### PR TITLE
[FIX]: install-freisa.sh: List ALL assigned IP addresses

### DIFF
--- a/docs/install-freisa.sh
+++ b/docs/install-freisa.sh
@@ -24,7 +24,7 @@ lsb_release -a
 dpkg -l bluez
 
 # Check assigned IP addresses
-hostname -i
+hostname -I
 
 # Check installed Bluetooth interfaces
 hciconfig -a


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description
<!-- Add a brief description of the pr -->

The `hostname` command was incorrectly using the the `-i` (lowercase) option which returned only one IP address.

Replace it with `-I` (uppercase) to list all the assigned IP addresses.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Reference: <https://manpages.ubuntu.com/manpages/jammy/man1/hostname.1.html>